### PR TITLE
Add showcase for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ If you rely heavily on mobile interactions and are looking for a mobile-first UI
 
 [**Read our FAQ on the wiki ▸**](https://github.com/palantir/blueprint/wiki/Frequently-Asked-Questions)
 
+[**Showcase ▸**](https://blueprintjs.surge.sh/)
+
 ### Bug report? Feature request? Support question?
 
 Choose the [appropriate issue type](https://github.com/palantir/blueprint/issues/new/choose) and fill out the template.


### PR DESCRIPTION
#### The following is not a bug fix.
- only read me updated

#### Changes proposed in this pull request:

Hi there!
I wanted to use a nice UI library for an upcoming project in Electron and since it doesn't need to scale to mobile, this works great!

However, I wanted to see all the components in one place. Here is a site that I built with surge.sh. It would be great if it could be added to the readme. [Here](https://github.com/samarthdave/blueprint_showcase) is the github link to the repo.

Showcase (its pretty simple and a work in progress so please write recommendations):
### [blueprintjs.surge.sh](https://blueprintjs.surge.sh)